### PR TITLE
Corrected Typo on contributor name in FAQ

### DIFF
--- a/source/faq.md
+++ b/source/faq.md
@@ -8,7 +8,7 @@ ARES sont les administrateurs réseaux de l'ENSIIE Strasbourg. Une association f
 ### Qui sont ses membres actifs?
 - Léo Unbekandt
 -  Paul Chobert
--  Luke Berthot
+-  Luke Bertot
 -  Philippe Gaultier
 -  Maxime Heckel
 -  Hao Pan


### PR DESCRIPTION
'git blame' dit que c'est Phil qu'il faut frapper.
